### PR TITLE
setup-python-dependencies: false

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,9 @@ jobs:
               with:
                   languages: ${{ matrix.language }}
                   config-file: ./.github/codeql/codeql-config.yml
+                  # Override the default behavior so that the action doesn't attempt
+                  # to auto-install Python dependencies
+                  setup-python-dependencies: false
 
             # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
             # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,16 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3
+              
+            - name: 'Setup Python version'
+              uses: actions/setup-python@v4
+              with:
+                  python-version: 3.11
+
+            - name: 'Set up the environment'
+              uses: ./.github/workflows/setup-poetry-env
+              with:
+                  python-version: 3.11
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL


### PR DESCRIPTION
Modify CodeQL scan to exclude results from dependencies
- [setup-python-dependencies: false](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#analyzing-python-dependencies)
-  Hardcoded to v [3.11](https://github.com/testing-felickz/setupr/blob/main/.github/workflows/on-pull-request.yml#L38)


You might consider baking into your existing CI with on-pull-request.yml and a workflow that runs against the default branch (to get [Code Scanning baseline used to compare the delta of PR scan results](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#scanning-pull-requests))
