### PR TITLE
autobuild + POETRY_VIRTUALENVS_IN_PROJECT: false

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,29 +33,19 @@ jobs:
             matrix:
                 language: ['python']
 
+        env:
+            POETRY_VIRTUALENVS_IN_PROJECT: false
+
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3
               
-            - name: 'Setup Python version'
-              uses: actions/setup-python@v4
-              with:
-                  python-version: 3.11
-
-            - name: 'Set up the environment'
-              uses: ./.github/workflows/setup-poetry-env
-              with:
-                  python-version: 3.11
-
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL
               uses: github/codeql-action/init@v2
               with:
                   languages: ${{ matrix.language }}
                   config-file: ./.github/codeql/codeql-config.yml
-                  # Override the default behavior so that the action doesn't attempt
-                  # to auto-install Python dependencies
-                  setup-python-dependencies: false
 
             # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
             # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
Manually testing out the fix  https://github.com/github/codeql-action/pull/1419 that was [merged to v2 release on 12/8](https://github.com/github/codeql-action/pull/1428)
- set the environment variable `POETRY_VIRTUALENVS_IN_PROJECT=false` in codeql workflow file so it's active while the codeql-action/init step runs. 

- 🟢 No alerts for .venv libs 🎉  