### PR TITLE
Restore initial CodeQL Workflow on with Python poetry venv fix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,6 @@
 name: 'CodeQL'
 
 on:
-    workflow_dispatch:
     push:
         branches: ['main']
     pull_request:
@@ -34,43 +33,19 @@ jobs:
                 language: ['python']
 
         steps:
-            - name: 'Checkout repository'
+            - name: Checkout repository
               uses: actions/checkout@v3
 
-            - name: 'Setup Python version'
-              uses: actions/setup-python@v4
-              with:
-                  python-version: 3.11
-
-            - name: 'Set up the environment'
-              uses: ./.github/workflows/setup-poetry-env
-              with:
-                  python-version: 3.11
-
-            - name: 'Set up the environment'
-              uses: ./.github/workflows/setup-poetry-env
-              with:
-                  python-version: ${{ matrix.python-version }}
-
-            # https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#analyzing-python-dependencies
-            - name: 'Analyzing Python dependencies'
-              run: |
-                  source .venv/bin/activate
-                  echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV
-
             # Initializes the CodeQL tools for scanning.
-            - name: 'Initialize CodeQL'
+            - name: Initialize CodeQL
               uses: github/codeql-action/init@v2
               with:
                   languages: ${{ matrix.language }}
                   config-file: ./.github/codeql/codeql-config.yml
-                  # Override the default behavior so that the action doesn't attempt
-                  # to auto-install Python dependencies
-                  setup-python-dependencies: false
 
             # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
             # If this step fails, then you should remove it and run the build manually (see below)
-            - name: 'Autobuild'
+            - name: Autobuild
               uses: github/codeql-action/autobuild@v2
 
             #   If the Autobuild fails above, remove it and uncomment the following three lines.
@@ -78,30 +53,7 @@ jobs:
             #   echo "Run, Build Application using script"
             #   ./location_of_script_within_repo/buildscript.sh
 
-            - name: 'Perform CodeQL Analysis'
+            - name: Perform CodeQL Analysis
               uses: github/codeql-action/analyze@v2
               with:
-                  language: python
                   category: '/language:${{matrix.language}}'
-                  upload: False
-                  output: sarif-results
-
-            - name: 'filter SARIF'
-              uses: advanced-security/filter-sarif@v1
-              with:
-                  patterns: |
-                      -**/.venv/**
-                  input: sarif-results/python.sarif
-                  output: sarif-results/python.sarif
-
-            - name: 'Upload SARIF'
-              uses: github/codeql-action/upload-sarif@v2
-              with:
-                  sarif_file: sarif-results/python.sarif
-
-            - name: 'Upload loc as a Build Artifact'
-              uses: actions/upload-artifact@v2.2.0
-              with:
-                  name: sarif-results
-                  path: sarif-results
-                  retention-days: 1


### PR DESCRIPTION
Revert back to [previous autobuild commit](https://github.com/worldr/setupr/commit/1584a575e0d884e6f7485e7be6bb5d8298c11a3d) ( implicit `setup-python-dependencies: [default] true` ) with new hotfix release to  `codeql/*@v2`
- https://github.com/github/codeql-action/pull/1419
- was [merged to v2 release on 12/8](https://github.com/github/codeql-action/pull/1428)